### PR TITLE
auto-closing queues inside LazyFutureStreams

### DIFF
--- a/src/main/java/com/aol/simple/react/async/AlwaysContinue.java
+++ b/src/main/java/com/aol/simple/react/async/AlwaysContinue.java
@@ -2,8 +2,8 @@ package com.aol.simple.react.async;
 
 public class AlwaysContinue implements Continueable{
 
-	public boolean closeQueueIfFinished(Queue queue){
-		return true;
+	public void closeQueueIfFinished(Queue queue){
+		
 	}
 
 	@Override
@@ -26,13 +26,13 @@ public class AlwaysContinue implements Continueable{
 
 	@Override
 	public boolean closed() {
-		// TODO Auto-generated method stub
+		
 		return false;
 	}
 
 	@Override
 	public void closeQueueIfFinishedStateless(Queue queue) {
-		// TODO Auto-generated method stub
+		
 		
 	}
 }

--- a/src/main/java/com/aol/simple/react/async/AlwaysContinue.java
+++ b/src/main/java/com/aol/simple/react/async/AlwaysContinue.java
@@ -1,0 +1,38 @@
+package com.aol.simple.react.async;
+
+public class AlwaysContinue implements Continueable{
+
+	public boolean closeQueueIfFinished(Queue queue){
+		return true;
+	}
+
+	@Override
+	public void addQueue(Queue queue) {
+		
+		
+	}
+	public void registerSkip(long skip){
+		
+	}
+	public void registerLimit(long limit){
+		
+	}
+
+	@Override
+	public void closeAll() {
+		
+		
+	}
+
+	@Override
+	public boolean closed() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public void closeQueueIfFinishedStateless(Queue queue) {
+		// TODO Auto-generated method stub
+		
+	}
+}

--- a/src/main/java/com/aol/simple/react/async/Continueable.java
+++ b/src/main/java/com/aol/simple/react/async/Continueable.java
@@ -2,7 +2,7 @@ package com.aol.simple.react.async;
 
 public interface Continueable {
 
-	public boolean closeQueueIfFinished(Queue queue);
+	public void closeQueueIfFinished(Queue queue);
 
 	public void addQueue(Queue queue);
 	public void registerSkip(long skip);

--- a/src/main/java/com/aol/simple/react/async/Continueable.java
+++ b/src/main/java/com/aol/simple/react/async/Continueable.java
@@ -1,0 +1,15 @@
+package com.aol.simple.react.async;
+
+public interface Continueable {
+
+	public boolean closeQueueIfFinished(Queue queue);
+
+	public void addQueue(Queue queue);
+	public void registerSkip(long skip);
+	public void registerLimit(long limit);
+	public void closeAll();
+
+	public boolean closed();
+
+	public void closeQueueIfFinishedStateless(Queue queue);
+}

--- a/src/main/java/com/aol/simple/react/async/Queue.java
+++ b/src/main/java/com/aol/simple/react/async/Queue.java
@@ -53,8 +53,7 @@ public class Queue<T> implements Adapter<T> {
 	
 	@Getter
 	private final Signal<Integer> sizeSignal;
-	
-	private volatile Continueable sub;
+
 
 	/**
 	 * Construct a Queue backed by a LinkedBlockingQueue
@@ -92,7 +91,6 @@ public class Queue<T> implements Adapter<T> {
 		return Seq.seq(closingStream(this::ensureOpen,new AlwaysContinue()));
 	}
 	public Seq<T> stream(Continueable s) {
-		this.sub=s;
 		listeningStreams.incrementAndGet(); //assumes all Streams that ever connected, remain connected
 		return Seq.seq(closingStream(this::ensureOpen,s));
 	}

--- a/src/main/java/com/aol/simple/react/async/Subscription.java
+++ b/src/main/java/com/aol/simple/react/async/Subscription.java
@@ -1,0 +1,128 @@
+package com.aol.simple.react.async;
+
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.jooq.lambda.Seq;
+
+@Getter
+@Setter
+public class Subscription implements Continueable{
+	private final Map<Queue,AtomicLong> limits = new HashMap<>();
+	
+	private final Map<Queue,AtomicBoolean> unlimited = new HashMap<>();
+	private final Map<Queue,AtomicLong> count = new HashMap<>();
+	private final List<Queue> queues = new LinkedList<>();
+	
+	private final AtomicBoolean closed=  new AtomicBoolean(false);
+	
+	public void registerSkip(long skip){
+		if(queues.size()>0)
+			limits.get(queues.get(queues.size()-1)).addAndGet(skip);
+	}
+	public void registerLimit(long limit){
+		
+		if(queues.size()>0){
+			if(unlimited.get(queues.get(queues.size()-1)).get())
+				limits.get(queues.get(queues.size()-1)).set(0);
+			
+			limits.get(queues.get(queues.size()-1)).addAndGet(limit);
+			unlimited.get(queues.get(queues.size()-1)).set(false);
+			
+			queues.stream().forEach(this::closeQueueIfFinishedStateless);
+			
+		}
+	}
+	public void addQueue(Queue q){
+	
+		queues.add(q);
+		limits.put(q, new AtomicLong(Long.MAX_VALUE-1));
+		unlimited.put(q, new AtomicBoolean(true));
+		count.put(q, new AtomicLong(0l));
+		
+	}
+	
+	
+	public boolean closeQueueIfFinished(Queue queue){
+		
+		if(queues.size()==0)
+			return true;
+		
+		long queueCount = count.get(queue).incrementAndGet();
+		long limit = valuesToRight(queue).stream().reduce((acc,next)-> Math.min(acc, next)).get();
+		
+		
+		
+		if(queueCount>=limit){ //last entry - close THIS queue only!
+			
+			queue.closeAndClear();
+			closed.set(true);
+		}
+		
+	
+		return true;
+		
+	}
+	public void closeQueueIfFinishedStateless(Queue queue){
+		
+		if(queues.size()==0)
+			return;
+		
+		long queueCount = count.get(queue).get();
+		long limit = valuesToRight(queue).stream().reduce((acc,next)-> Math.min(acc, next)).get();
+		
+		
+		
+		
+		if(queueCount>=limit){ //last entry - close THIS queue only!
+			
+			queue.closeAndClear();
+			closed.set(true);
+		}
+		
+	
+		
+		
+	}
+	private List<Long> valuesToRight(Queue queue) {
+		return Seq.seq(queues.stream()).splitAt(findQueue(queue)).v2.map(limits::get).map(AtomicLong::get).collect(Collectors.toList());
+		
+	}
+	
+	private int findQueue(Queue queue){
+		for(int i=0;i< queues.size();i++){
+			if(queues.get(i) == queue)
+				return i;
+		}
+		return -1;
+	}
+	@Override
+	public void closeAll() {
+		closed.set(true);
+		queues.stream().forEach(Queue::closeAndClear);
+		
+	}
+	@Override
+	public boolean closed() {
+		return closed.get();
+	}
+}
+/**
+stream.map().iterator().limit(4).flatMap().limit(2).iterator().limit(8)
+subscription
+
+stream no limit
+	q1:limit (4)
+	q2:limit (2)
+	q3:limit (8)
+	**/
+

--- a/src/main/java/com/aol/simple/react/stream/BaseLazySimpleReact.java
+++ b/src/main/java/com/aol/simple/react/stream/BaseLazySimpleReact.java
@@ -1,0 +1,42 @@
+package com.aol.simple.react.stream;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import com.aol.simple.react.async.Subscription;
+import com.aol.simple.react.stream.traits.SimpleReactStream;
+
+public abstract class BaseLazySimpleReact extends BaseSimpleReact{
+	/**
+	 * Generate an infinite reactive flow. Requires a lazy flow.
+	 * 
+	 * The flow will run indefinitely unless / until the provided Supplier throws an Exception
+	 * 
+	 * @see com.aol.simple.react.async.Queue   SimpleReact Queue for a way to create a more managable infinit flow
+	 * 
+	 * @param s Supplier to generate the infinite flow
+	 * @return Next stage in the flow
+	 */
+	public <U> SimpleReactStream< U> reactInfinitely(final Supplier<U> s) {
+		if(isEager())
+			throw new InfiniteProcessingException("To reactInfinitely use a lazy stream");
+		Subscription sub = new Subscription();
+		SimpleReactStream stream = construct(StreamSupport.stream(
+                new InfiniteClosingSpliterator(Long.MAX_VALUE, () -> CompletableFuture.completedFuture(s.get()),sub), false),
+				this.getExecutor(),getRetrier(),false).withSubscription(sub);
+		
+		return stream;
+		
+
+	}
+	
+	public <U> SimpleReactStream<U> iterateInfinitely(final U seed, final UnaryOperator<U> f){
+		if(isEager())
+			throw new InfiniteProcessingException("To iterateInfinitely use a lazy stream");
+		return construct(Stream.iterate(seed, it -> f.apply(it)).map(it -> CompletableFuture.completedFuture(it)),
+				this.getExecutor(),getRetrier(),false);
+	}
+}

--- a/src/main/java/com/aol/simple/react/stream/BaseSimpleReact.java
+++ b/src/main/java/com/aol/simple/react/stream/BaseSimpleReact.java
@@ -156,7 +156,7 @@ public abstract class BaseSimpleReact {
 		SimpleReactStream stream = construct(StreamSupport.stream(
                 new InfiniteClosingSpliterator(Long.MAX_VALUE, () -> CompletableFuture.completedFuture(s.get()),sub), false),
 				this.getExecutor(),getRetrier(),false).withSubscription(sub);
-		//return stream.fromStream(stream.toQueue().stream(sub));
+		
 		return stream;
 		
 

--- a/src/main/java/com/aol/simple/react/stream/BaseSimpleReact.java
+++ b/src/main/java/com/aol/simple/react/stream/BaseSimpleReact.java
@@ -139,35 +139,7 @@ public abstract class BaseSimpleReact {
 				this.getExecutor(),getRetrier(),isEager());
 
 	}
-	/**
-	 * Generate an infinite reactive flow. Requires a lazy flow.
-	 * 
-	 * The flow will run indefinitely unless / until the provided Supplier throws an Exception
-	 * 
-	 * @see com.aol.simple.react.async.Queue   SimpleReact Queue for a way to create a more managable infinit flow
-	 * 
-	 * @param s Supplier to generate the infinite flow
-	 * @return Next stage in the flow
-	 */
-	public <U> SimpleReactStream< U> reactInfinitely(final Supplier<U> s) {
-		if(isEager())
-			throw new InfiniteProcessingException("To reactInfinitely use a lazy stream");
-		Subscription sub = new Subscription();
-		SimpleReactStream stream = construct(StreamSupport.stream(
-                new InfiniteClosingSpliterator(Long.MAX_VALUE, () -> CompletableFuture.completedFuture(s.get()),sub), false),
-				this.getExecutor(),getRetrier(),false).withSubscription(sub);
-		
-		return stream;
-		
-
-	}
 	
-	public <U> SimpleReactStream<U> iterateInfinitely(final U seed, final UnaryOperator<U> f){
-		if(isEager())
-			throw new InfiniteProcessingException("To iterateInfinitely use a lazy stream");
-		return construct(Stream.iterate(seed, it -> f.apply(it)).map(it -> CompletableFuture.completedFuture(it)),
-				this.getExecutor(),getRetrier(),false);
-	}
 	/**
 	 * Create a Sequential Generator that will trigger a Supplier to be called the specified number of times
 	 * 

--- a/src/main/java/com/aol/simple/react/stream/BaseSimpleReact.java
+++ b/src/main/java/com/aol/simple/react/stream/BaseSimpleReact.java
@@ -3,18 +3,16 @@ package com.aol.simple.react.stream;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
-import lombok.Getter;
-import lombok.experimental.Builder;
-
+import com.aol.simple.react.async.ClosingSpliterator;
+import com.aol.simple.react.async.Subscription;
 import com.aol.simple.react.generators.Generator;
 import com.aol.simple.react.generators.ParallelGenerator;
 import com.aol.simple.react.generators.ReactIterator;
@@ -154,8 +152,13 @@ public abstract class BaseSimpleReact {
 	public <U> SimpleReactStream< U> reactInfinitely(final Supplier<U> s) {
 		if(isEager())
 			throw new InfiniteProcessingException("To reactInfinitely use a lazy stream");
-		return construct(Stream.generate(() -> CompletableFuture.completedFuture(s.get())),
-				this.getExecutor(),getRetrier(),false);
+		Subscription sub = new Subscription();
+		SimpleReactStream stream = construct(StreamSupport.stream(
+                new InfiniteClosingSpliterator(Long.MAX_VALUE, () -> CompletableFuture.completedFuture(s.get()),sub), false),
+				this.getExecutor(),getRetrier(),false).withSubscription(sub);
+		//return stream.fromStream(stream.toQueue().stream(sub));
+		return stream;
+		
 
 	}
 	

--- a/src/main/java/com/aol/simple/react/stream/CloseableIterator.java
+++ b/src/main/java/com/aol/simple/react/stream/CloseableIterator.java
@@ -1,0 +1,20 @@
+package com.aol.simple.react.stream;
+
+import java.util.Iterator;
+
+import lombok.AllArgsConstructor;
+import lombok.experimental.Delegate;
+
+import com.aol.simple.react.async.Continueable;
+
+@AllArgsConstructor
+public class CloseableIterator<T> implements Iterator<T>{
+
+	@Delegate
+	private final Iterator<T> iterator;
+	private final Continueable subscription;
+	
+	public void close(){
+		subscription.closeAll();
+	}
+}

--- a/src/main/java/com/aol/simple/react/stream/InfiniteClosingSpliterator.java
+++ b/src/main/java/com/aol/simple/react/stream/InfiniteClosingSpliterator.java
@@ -1,0 +1,77 @@
+package com.aol.simple.react.stream;
+
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import com.aol.simple.react.async.ClosingSpliterator;
+import com.aol.simple.react.async.Continueable;
+import com.aol.simple.react.async.Queue;
+import com.aol.simple.react.async.Queue.ClosedQueueException;
+
+public class InfiniteClosingSpliterator<T> implements Spliterator<T> {
+    private long estimate;
+    final Supplier<T> s;
+    private final Continueable subscription;
+    private final Queue queue;
+
+    protected InfiniteClosingSpliterator(long estimate,Supplier<T> s,
+    		Continueable subscription,
+    		Queue queue) {
+        this.estimate = estimate;
+        this.s = s;
+        this.subscription = subscription;
+        this.queue = queue;
+        this.subscription.addQueue(queue);
+    }
+    public InfiniteClosingSpliterator(long estimate,Supplier<T> s,
+    		Continueable subscription) {
+        this.estimate = estimate;
+        this.s = s;
+        this.subscription = subscription;
+        this.queue = null;
+    }
+
+    @Override
+    public long estimateSize() {
+        return estimate;
+    }
+
+    @Override
+    public int characteristics() {
+        return IMMUTABLE;
+    }
+    
+
+
+	@Override
+	public boolean tryAdvance(Consumer<? super T> action) {
+		 Objects.requireNonNull(action);
+		
+			
+        try{ 
+        	
+        	action.accept(s.get());
+        	if(subscription.closed())
+        		return false;
+        	return true;
+        }catch(ClosedQueueException e){
+        	return false;
+        }catch(Exception e){
+        	
+        	return false;
+        }
+        
+	}
+
+	@Override
+	public Spliterator<T> trySplit() {
+		
+		return new InfiniteClosingSpliterator(estimate >>>= 1, s,subscription,queue);
+	}
+
+   
+}
+
+

--- a/src/main/java/com/aol/simple/react/stream/Runner.java
+++ b/src/main/java/com/aol/simple/react/stream/Runner.java
@@ -19,10 +19,15 @@ public class Runner {
 
 				collector.accept(n);
 			});
+			collector.getResults();
 		} catch (SimpleReactProcessingException e) {
 		
+		}catch(java.util.concurrent.CompletionException e){
+			
+		}catch(Throwable e){
+			e.printStackTrace();
 		}
-		collector.getResults();
+		
 		runnable.run();
 		return true;
 

--- a/src/main/java/com/aol/simple/react/stream/ThreadPools.java
+++ b/src/main/java/com/aol/simple/react/stream/ThreadPools.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 
 public class ThreadPools {
 	@Getter
-	private static final ExecutorService commonFreeThread = new ForkJoinPool(1);
+	private static final ExecutorService commonFreeThread =  Executors.newFixedThreadPool(1);
 	
 	@Getter
 	private static final ExecutorService commonLazyExecutor = new ForkJoinPool(1);
@@ -21,6 +21,7 @@ public class ThreadPools {
 	@Getter
 	private static final ScheduledExecutorService commonStanardRetry = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
 
+	
 	
 	@Setter
 	private static volatile boolean useCommon = true;
@@ -33,7 +34,7 @@ public class ThreadPools {
 		if(useCommon)
 			return commonFreeThread;
 		else
-		return new ForkJoinPool(1);
+			return new ForkJoinPool(1);
 	}
 	public static ScheduledExecutorService getSequentialRetry() {
 		if(useCommon)

--- a/src/main/java/com/aol/simple/react/stream/eager/EagerFutureStream.java
+++ b/src/main/java/com/aol/simple/react/stream/eager/EagerFutureStream.java
@@ -28,6 +28,7 @@ import com.aol.simple.react.RetryBuilder;
 import com.aol.simple.react.exceptions.SimpleReactFailedStageException;
 import com.aol.simple.react.stream.StreamWrapper;
 import com.aol.simple.react.stream.ThreadPools;
+import com.aol.simple.react.stream.lazy.LazyFutureStream;
 import com.aol.simple.react.stream.simple.SimpleReact;
 import com.aol.simple.react.stream.traits.EagerToQueue;
 import com.aol.simple.react.stream.traits.FutureStream;
@@ -44,7 +45,16 @@ import com.nurkiewicz.asyncretry.RetryExecutor;
  */
 public interface EagerFutureStream<U> extends FutureStream<U>, EagerToQueue<U> {
 
-	
+	/* 
+	 * React to new events with the supplied function on the supplied ExecutorService
+	 * 
+	 *	@param fn Apply to incoming events
+	 *	@param service Service to execute function on 
+	 *	@return next stage in the Stream
+	 */
+	default <R> EagerFutureStream<R> then(final Function<U, R> fn, ExecutorService service){
+		return (EagerFutureStream<R>)FutureStream.super.then(fn, service);
+	}
 	
 	/* 
 	 * Non-blocking asyncrhonous application of the supplied function.

--- a/src/main/java/com/aol/simple/react/stream/eager/EagerFutureStreamImpl.java
+++ b/src/main/java/com/aol/simple/react/stream/eager/EagerFutureStreamImpl.java
@@ -15,6 +15,8 @@ import lombok.experimental.Wither;
 import lombok.extern.slf4j.Slf4j;
 
 import com.aol.simple.react.RetryBuilder;
+import com.aol.simple.react.async.AlwaysContinue;
+import com.aol.simple.react.async.Continueable;
 import com.aol.simple.react.async.QueueFactories;
 import com.aol.simple.react.async.QueueFactory;
 import com.aol.simple.react.capacity.monitor.LimitingMonitor;
@@ -42,6 +44,7 @@ public class EagerFutureStreamImpl<U> implements EagerFutureStream<U>{
 	private final LazyResultConsumer<U> lazyCollector;
 	private final QueueFactory<U> queueFactory;
 	private final BaseSimpleReact simpleReact;
+	private final Continueable subscription;
 	/**
 	 * 
 	 * Construct a SimpleReact stage - this acts as a fluent SimpleReact builder
@@ -65,6 +68,7 @@ public class EagerFutureStreamImpl<U> implements EagerFutureStream<U>{
 		this.waitStrategy = new LimitingMonitor();
 		this.lazyCollector = new BatchingCollector<>();
 		this.queueFactory = QueueFactories.unboundedQueue();
+		subscription = new AlwaysContinue();
 	}
 
 	@Override

--- a/src/main/java/com/aol/simple/react/stream/eager/EagerFutureStreamImpl.java
+++ b/src/main/java/com/aol/simple/react/stream/eager/EagerFutureStreamImpl.java
@@ -46,7 +46,7 @@ public class EagerFutureStreamImpl<U> implements EagerFutureStream<U>{
 	private final QueueFactory<U> queueFactory;
 	private final BaseSimpleReact simpleReact;
 	private final Continueable subscription;
-	private final ExecutorService taskExecutor2 = null;
+	private final ExecutorService populator = null;
 	/**
 	 * 
 	 * Construct a SimpleReact stage - this acts as a fluent SimpleReact builder
@@ -71,6 +71,7 @@ public class EagerFutureStreamImpl<U> implements EagerFutureStream<U>{
 		this.lazyCollector = new BatchingCollector<>();
 		this.queueFactory = QueueFactories.unboundedQueue();
 		subscription = new AlwaysContinue();
+		
 	}
 
 	@Override

--- a/src/main/java/com/aol/simple/react/stream/eager/EagerFutureStreamImpl.java
+++ b/src/main/java/com/aol/simple/react/stream/eager/EagerFutureStreamImpl.java
@@ -3,6 +3,7 @@ package com.aol.simple.react.stream.eager;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Consumer;
 import java.util.stream.Collector;
@@ -45,6 +46,7 @@ public class EagerFutureStreamImpl<U> implements EagerFutureStream<U>{
 	private final QueueFactory<U> queueFactory;
 	private final BaseSimpleReact simpleReact;
 	private final Continueable subscription;
+	private final ExecutorService taskExecutor2 = null;
 	/**
 	 * 
 	 * Construct a SimpleReact stage - this acts as a fluent SimpleReact builder

--- a/src/main/java/com/aol/simple/react/stream/lazy/LazyFutureStream.java
+++ b/src/main/java/com/aol/simple/react/stream/lazy/LazyFutureStream.java
@@ -61,7 +61,16 @@ public interface LazyFutureStream<U> extends FutureStream<U>, LazyToQueue<U> {
 	
 	LazyFutureStream<U> withLastActive(StreamWrapper streamWrapper);
 	
-	
+	/* 
+	 * React to new events with the supplied function on the supplied ExecutorService
+	 * 
+	 *	@param fn Apply to incoming events
+	 *	@param service Service to execute function on 
+	 *	@return next stage in the Stream
+	 */
+	default <R> LazyFutureStream<R> then(final Function<U, R> fn, ExecutorService service){
+		return (LazyFutureStream<R>)FutureStream.super.then(fn, service);
+	}
 	
 	/**
 	 * Override return type on SimpleReactStream

--- a/src/main/java/com/aol/simple/react/stream/lazy/LazyFutureStream.java
+++ b/src/main/java/com/aol/simple/react/stream/lazy/LazyFutureStream.java
@@ -6,10 +6,12 @@ import static java.util.Spliterators.spliteratorUnknownSize;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -20,13 +22,18 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.jooq.lambda.Seq;
+import org.jooq.lambda.tuple.Tuple;
 import org.jooq.lambda.tuple.Tuple2;
 
 import com.aol.simple.react.RetryBuilder;
+import com.aol.simple.react.async.Continueable;
+import com.aol.simple.react.async.QueueFactory;
+import com.aol.simple.react.async.Subscription;
+import com.aol.simple.react.collectors.lazy.LazyResultConsumer;
 import com.aol.simple.react.exceptions.SimpleReactFailedStageException;
+import com.aol.simple.react.stream.CloseableIterator;
 import com.aol.simple.react.stream.StreamWrapper;
 import com.aol.simple.react.stream.ThreadPools;
-import com.aol.simple.react.stream.eager.EagerFutureStream;
 import com.aol.simple.react.stream.traits.FutureStream;
 import com.aol.simple.react.stream.traits.LazyToQueue;
 import com.aol.simple.react.stream.traits.SimpleReactStream;
@@ -40,6 +47,17 @@ import com.nurkiewicz.asyncretry.RetryExecutor;
  */
 public interface LazyFutureStream<U> extends FutureStream<U>, LazyToQueue<U> {
 
+	
+	LazyFutureStream<U> withTaskExecutor(ExecutorService e);
+	LazyFutureStream<U> withRetrier(RetryExecutor retry);
+	LazyFutureStream<U> withWaitStrategy(Consumer<CompletableFuture> c);
+	LazyFutureStream<U> withEager(boolean eager);
+	LazyFutureStream<U> withLazyCollector(LazyResultConsumer<U> lazy);
+	LazyFutureStream<U> withQueueFactory(QueueFactory<U> queue);
+	
+	LazyFutureStream<U>  withErrorHandler(Optional<Consumer<Throwable>> errorHandler);
+	LazyFutureStream<U> withSubscription(Continueable sub);
+	
 	LazyFutureStream<U> withLastActive(StreamWrapper streamWrapper);
 	
 	/**
@@ -295,11 +313,17 @@ public interface LazyFutureStream<U> extends FutureStream<U>, LazyToQueue<U> {
 	@Override
 	default LazyFutureStream<U> limit(long maxSize) {
 
+		Continueable  sub = this.getSubscription();
+		sub.registerLimit(maxSize);
 		StreamWrapper lastActive = getLastActive();
 		StreamWrapper limited = lastActive.withStream(lastActive.stream().limit(maxSize));
 		return this.withLastActive(limited);
 
 	}
+
+	
+
+	
 
 	/* 
 	 * LazyFutureStream.of(1,2,3,4).skip(2)
@@ -312,6 +336,8 @@ public interface LazyFutureStream<U> extends FutureStream<U>, LazyToQueue<U> {
 	 */
 	@Override
 	default LazyFutureStream<U> skip(long n) {
+		Continueable sub = this.getSubscription();
+		sub.registerSkip(n);
 		StreamWrapper lastActive = getLastActive();
 		StreamWrapper limited = lastActive.withStream(lastActive.stream().skip(n));
 		return this.withLastActive(limited);
@@ -338,7 +364,7 @@ public interface LazyFutureStream<U> extends FutureStream<U>, LazyToQueue<U> {
 	@Override
 	default Seq<U> distinct() {
 		
-		return toQueue().stream().distinct();
+		return toQueue().stream(getSubscription()).distinct();
 	}
 
 	/**
@@ -373,6 +399,36 @@ public interface LazyFutureStream<U> extends FutureStream<U>, LazyToQueue<U> {
 		return new Tuple2(partitioned.v1, partitioned.v2);
 	}
 
+	/**
+     * Zip two streams into one.
+     * <p>
+     * <code><pre>
+     * // (tuple(1, "a"), tuple(2, "b"), tuple(3, "c"))
+     * Seq.of(1, 2, 3).zip(Seq.of("a", "b", "c"))
+     * </pre></code>
+     *
+     * @see #zip(Stream, Stream)
+     */
+    default <T> Seq<Tuple2<U, T>> zip(Seq<T> other) {
+        return zip(this, other);
+    }
+
+    /**
+     * Zip two streams into one using a {@link BiFunction} to produce resulting values.
+     * <p>
+     * <code><pre>
+     * // ("1:a", "2:b", "3:c")
+     * Seq.of(1, 2, 3).zip(Seq.of("a", "b", "c"), (i, s) -> i + ":" + s)
+     * </pre></code>
+     *
+     * @see #zip(Seq, BiFunction)
+     */
+    default <T, R> Seq<R> zip(Seq<T> other, BiFunction<U, T, R> zipper) {
+        return zip(this, other, zipper);
+    }
+
+  
+	
 	/**
 	 * Construct a SimpleReact Stage from a supplied array
 	 * 
@@ -524,7 +580,7 @@ public interface LazyFutureStream<U> extends FutureStream<U>, LazyToQueue<U> {
 		if (stream instanceof LazyFutureStream)
 			return (LazyFutureStream<T>) stream;
 		if (stream instanceof FutureStream)
-			stream = ((FutureStream) stream).toQueue().stream();
+			stream = ((FutureStream) stream).toQueue().stream(((FutureStream) stream).getSubscription());
 
 		return new LazyFutureStreamImpl<T>(
 				stream.map(CompletableFuture::completedFuture),
@@ -547,5 +603,56 @@ public interface LazyFutureStream<U> extends FutureStream<U>, LazyToQueue<U> {
 		return futureStream(StreamSupport.stream(
 				spliteratorUnknownSize(iterator, ORDERED), false));
 	}
+	
+	 /**
+     * Zip two streams into one.
+     * <p>
+     * <code><pre>
+     * // (tuple(1, "a"), tuple(2, "b"), tuple(3, "c"))
+     * Seq.of(1, 2, 3).zip(Seq.of("a", "b", "c"))
+     * </pre></code>
+     */
+    static <T1, T2> Seq<Tuple2<T1, T2>> zip(Stream<T1> left, Stream<T2> right) {
+        return zip(left, right, Tuple::tuple);
+    }
 
+    /**
+     * Zip two streams into one using a {@link BiFunction} to produce resulting values.
+     * <p>
+     * <code><pre>
+     * // ("1:a", "2:b", "3:c")
+     * Seq.of(1, 2, 3).zip(Seq.of("a", "b", "c"), (i, s) -> i + ":" + s)
+     * </pre></code>
+     */
+    static <T1, T2, R> Seq<R> zip(Stream<T1> left, Stream<T2> right, BiFunction<T1, T2, R> zipper) {
+        final Iterator<T1> it1 = left.iterator();
+        final Iterator<T2> it2 = right.iterator();
+
+        class Zip implements Iterator<R> {
+            @Override
+            public boolean hasNext() {
+            	if(!it1.hasNext()){
+            		close(it2);
+            	}
+            	if(!it2.hasNext()){
+            		close(it1);
+            	}
+                return it1.hasNext() && it2.hasNext();
+            }
+
+            @Override
+            public R next() {
+                return zipper.apply(it1.next(), it2.next());
+            }
+        }
+
+        return Seq.seq(new Zip());
+    }
+	
+    static void close(Iterator it){
+    	if(it instanceof CloseableIterator){
+    		((CloseableIterator)it).close();
+    	}
+    }
+    
 }

--- a/src/main/java/com/aol/simple/react/stream/lazy/LazyFutureStream.java
+++ b/src/main/java/com/aol/simple/react/stream/lazy/LazyFutureStream.java
@@ -18,6 +18,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -59,6 +60,8 @@ public interface LazyFutureStream<U> extends FutureStream<U>, LazyToQueue<U> {
 	LazyFutureStream<U> withSubscription(Continueable sub);
 	
 	LazyFutureStream<U> withLastActive(StreamWrapper streamWrapper);
+	
+	
 	
 	/**
 	 * Override return type on SimpleReactStream
@@ -650,6 +653,7 @@ public interface LazyFutureStream<U> extends FutureStream<U>, LazyToQueue<U> {
     }
 	
     static void close(Iterator it){
+    	
     	if(it instanceof CloseableIterator){
     		((CloseableIterator)it).close();
     	}

--- a/src/main/java/com/aol/simple/react/stream/lazy/LazyFutureStreamImpl.java
+++ b/src/main/java/com/aol/simple/react/stream/lazy/LazyFutureStreamImpl.java
@@ -25,6 +25,7 @@ import com.aol.simple.react.collectors.lazy.BatchingCollector;
 import com.aol.simple.react.collectors.lazy.LazyResultConsumer;
 import com.aol.simple.react.stream.BaseSimpleReact;
 import com.aol.simple.react.stream.StreamWrapper;
+import com.aol.simple.react.stream.ThreadPools;
 import com.nurkiewicz.asyncretry.AsyncRetryExecutor;
 import com.nurkiewicz.asyncretry.RetryExecutor;
 
@@ -47,7 +48,7 @@ public class LazyFutureStreamImpl<U> implements LazyFutureStream<U>{
 	private final QueueFactory<U> queueFactory;
 	private final BaseSimpleReact simpleReact;
 	private final Continueable subscription;
-	private final ExecutorService taskExecutor2 = Executors.newFixedThreadPool(1);
+	
 	
 	
 	LazyFutureStreamImpl(final Stream<CompletableFuture<U>> stream,
@@ -66,8 +67,12 @@ public class LazyFutureStreamImpl<U> implements LazyFutureStream<U>{
 		this.lazyCollector = new BatchingCollector<>();
 		this.queueFactory = QueueFactories.boundedQueue(1000);
 		this.subscription = new Subscription();
+		
 	}
 
+	public ExecutorService getPopulator(){
+		return Executors.newSingleThreadExecutor();
+	}
 	
 	@Override
 	public <R, A> R collect(Collector<? super U, A, R> collector) {

--- a/src/main/java/com/aol/simple/react/stream/lazy/LazyFutureStreamImpl.java
+++ b/src/main/java/com/aol/simple/react/stream/lazy/LazyFutureStreamImpl.java
@@ -15,8 +15,10 @@ import lombok.experimental.Wither;
 import lombok.extern.slf4j.Slf4j;
 
 import com.aol.simple.react.RetryBuilder;
+import com.aol.simple.react.async.Continueable;
 import com.aol.simple.react.async.QueueFactories;
 import com.aol.simple.react.async.QueueFactory;
+import com.aol.simple.react.async.Subscription;
 import com.aol.simple.react.capacity.monitor.LimitingMonitor;
 import com.aol.simple.react.collectors.lazy.BatchingCollector;
 import com.aol.simple.react.collectors.lazy.LazyResultConsumer;
@@ -42,6 +44,8 @@ public class LazyFutureStreamImpl<U> implements LazyFutureStream<U>{
 	private final LazyResultConsumer<U> lazyCollector;
 	private final QueueFactory<U> queueFactory;
 	private final BaseSimpleReact simpleReact;
+	private final Continueable subscription;
+	
 	
 	LazyFutureStreamImpl(final Stream<CompletableFuture<U>> stream,
 			final ExecutorService executor, final RetryExecutor retrier) {
@@ -58,6 +62,7 @@ public class LazyFutureStreamImpl<U> implements LazyFutureStream<U>{
 		this.waitStrategy = new LimitingMonitor();
 		this.lazyCollector = new BatchingCollector<>();
 		this.queueFactory = QueueFactories.boundedQueue(1000);
+		this.subscription = new Subscription();
 	}
 
 	

--- a/src/main/java/com/aol/simple/react/stream/lazy/LazyFutureStreamImpl.java
+++ b/src/main/java/com/aol/simple/react/stream/lazy/LazyFutureStreamImpl.java
@@ -3,6 +3,7 @@ package com.aol.simple.react.stream.lazy;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Consumer;
 import java.util.stream.Collector;
@@ -24,6 +25,7 @@ import com.aol.simple.react.collectors.lazy.BatchingCollector;
 import com.aol.simple.react.collectors.lazy.LazyResultConsumer;
 import com.aol.simple.react.stream.BaseSimpleReact;
 import com.aol.simple.react.stream.StreamWrapper;
+import com.nurkiewicz.asyncretry.AsyncRetryExecutor;
 import com.nurkiewicz.asyncretry.RetryExecutor;
 
 @Wither
@@ -45,6 +47,7 @@ public class LazyFutureStreamImpl<U> implements LazyFutureStream<U>{
 	private final QueueFactory<U> queueFactory;
 	private final BaseSimpleReact simpleReact;
 	private final Continueable subscription;
+	private final ExecutorService taskExecutor2 = Executors.newFixedThreadPool(1);
 	
 	
 	LazyFutureStreamImpl(final Stream<CompletableFuture<U>> stream,

--- a/src/main/java/com/aol/simple/react/stream/lazy/LazyReact.java
+++ b/src/main/java/com/aol/simple/react/stream/lazy/LazyReact.java
@@ -17,10 +17,8 @@ import lombok.experimental.Wither;
 
 import com.aol.simple.react.generators.Generator;
 import com.aol.simple.react.generators.ReactIterator;
-import com.aol.simple.react.stream.BaseSimpleReact;
+import com.aol.simple.react.stream.BaseLazySimpleReact;
 import com.aol.simple.react.stream.ThreadPools;
-import com.aol.simple.react.stream.eager.EagerFutureStream;
-import com.aol.simple.react.stream.traits.SimpleReactStream;
 import com.nurkiewicz.asyncretry.RetryExecutor;
 
 /**
@@ -33,7 +31,7 @@ import com.nurkiewicz.asyncretry.RetryExecutor;
 @Builder
 @Wither
 @AllArgsConstructor
-public class LazyReact extends BaseSimpleReact {
+public class LazyReact extends BaseLazySimpleReact {
 
 	@Getter
 	private final ExecutorService executor;

--- a/src/main/java/com/aol/simple/react/stream/lazy/LazyReact.java
+++ b/src/main/java/com/aol/simple/react/stream/lazy/LazyReact.java
@@ -71,6 +71,7 @@ public class LazyReact extends BaseSimpleReact {
 		return (LazyFutureStream) new LazyFutureStreamImpl<U>( s,executor, retrier);
 
 	}
+	
 
 	/* 
 	 * Construct a LazyFutureStream from the provided Stream of completableFutures

--- a/src/main/java/com/aol/simple/react/stream/simple/SimpleReact.java
+++ b/src/main/java/com/aol/simple/react/stream/simple/SimpleReact.java
@@ -20,7 +20,7 @@ import com.aol.simple.react.generators.Generator;
 import com.aol.simple.react.generators.ParallelGenerator;
 import com.aol.simple.react.generators.ReactIterator;
 import com.aol.simple.react.generators.SequentialIterator;
-import com.aol.simple.react.stream.BaseSimpleReact;
+import com.aol.simple.react.stream.BaseLazySimpleReact;
 import com.aol.simple.react.stream.InfiniteProcessingException;
 import com.aol.simple.react.stream.MissingValue;
 import com.aol.simple.react.stream.ThreadPools;
@@ -39,7 +39,7 @@ import com.nurkiewicz.asyncretry.RetryExecutor;
 
 @Builder
 @Wither
-public class SimpleReact  extends BaseSimpleReact{
+public class SimpleReact  extends BaseLazySimpleReact{
 
 	@Getter
 	private final ExecutorService executor;

--- a/src/main/java/com/aol/simple/react/stream/simple/SimpleReactStreamImpl.java
+++ b/src/main/java/com/aol/simple/react/stream/simple/SimpleReactStreamImpl.java
@@ -45,7 +45,7 @@ public class SimpleReactStreamImpl<U> implements SimpleReactStream<U>{
 	private final QueueFactory<U> queueFactory;
 	private final BaseSimpleReact simpleReact;
 	private final Continueable subscription;
-	private final ExecutorService taskExecutor2;
+
 	
 	public SimpleReactStreamImpl(final Stream<CompletableFuture<U>> stream,
 			final ExecutorService executor, final RetryExecutor retrier,boolean isEager) {
@@ -62,6 +62,9 @@ public class SimpleReactStreamImpl<U> implements SimpleReactStream<U>{
 		this.lazyCollector = new BatchingCollector<>();
 		this.queueFactory = eager ? QueueFactories.unboundedQueue() : QueueFactories.boundedQueue(1000);
 		this.subscription = new AlwaysContinue();
-		taskExecutor2=null;
+		
+	}
+	public ExecutorService getPopulator(){
+		return Executors.newSingleThreadExecutor();
 	}
 }

--- a/src/main/java/com/aol/simple/react/stream/simple/SimpleReactStreamImpl.java
+++ b/src/main/java/com/aol/simple/react/stream/simple/SimpleReactStreamImpl.java
@@ -14,6 +14,8 @@ import lombok.experimental.Wither;
 import lombok.extern.slf4j.Slf4j;
 
 import com.aol.simple.react.RetryBuilder;
+import com.aol.simple.react.async.AlwaysContinue;
+import com.aol.simple.react.async.Continueable;
 import com.aol.simple.react.async.QueueFactories;
 import com.aol.simple.react.async.QueueFactory;
 import com.aol.simple.react.capacity.monitor.LimitingMonitor;
@@ -41,6 +43,7 @@ public class SimpleReactStreamImpl<U> implements SimpleReactStream<U>{
 	private final LazyResultConsumer<U> lazyCollector;
 	private final QueueFactory<U> queueFactory;
 	private final BaseSimpleReact simpleReact;
+	private final Continueable subscription;
 	
 	public SimpleReactStreamImpl(final Stream<CompletableFuture<U>> stream,
 			final ExecutorService executor, final RetryExecutor retrier,boolean isEager) {
@@ -56,5 +59,6 @@ public class SimpleReactStreamImpl<U> implements SimpleReactStream<U>{
 		this.waitStrategy = new LimitingMonitor();
 		this.lazyCollector = new BatchingCollector<>();
 		this.queueFactory = eager ? QueueFactories.unboundedQueue() : QueueFactories.boundedQueue(1000);
+		this.subscription = new AlwaysContinue();
 	}
 }

--- a/src/main/java/com/aol/simple/react/stream/simple/SimpleReactStreamImpl.java
+++ b/src/main/java/com/aol/simple/react/stream/simple/SimpleReactStreamImpl.java
@@ -3,6 +3,7 @@ package com.aol.simple.react.stream.simple;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -44,6 +45,7 @@ public class SimpleReactStreamImpl<U> implements SimpleReactStream<U>{
 	private final QueueFactory<U> queueFactory;
 	private final BaseSimpleReact simpleReact;
 	private final Continueable subscription;
+	private final ExecutorService taskExecutor2;
 	
 	public SimpleReactStreamImpl(final Stream<CompletableFuture<U>> stream,
 			final ExecutorService executor, final RetryExecutor retrier,boolean isEager) {
@@ -60,5 +62,6 @@ public class SimpleReactStreamImpl<U> implements SimpleReactStream<U>{
 		this.lazyCollector = new BatchingCollector<>();
 		this.queueFactory = eager ? QueueFactories.unboundedQueue() : QueueFactories.boundedQueue(1000);
 		this.subscription = new AlwaysContinue();
+		taskExecutor2=null;
 	}
 }

--- a/src/main/java/com/aol/simple/react/stream/traits/ConfigurableStream.java
+++ b/src/main/java/com/aol/simple/react/stream/traits/ConfigurableStream.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
+import com.aol.simple.react.async.Continueable;
 import com.aol.simple.react.async.QueueFactory;
 import com.aol.simple.react.collectors.lazy.LazyResultConsumer;
 import com.aol.simple.react.stream.BaseSimpleReact;
@@ -21,6 +22,7 @@ public interface ConfigurableStream<T> {
 	SimpleReactStream<T> withQueueFactory(QueueFactory<T> queue);
 	SimpleReactStream<T> withLastActive(StreamWrapper streamWrapper);
 	SimpleReactStream<T>  withErrorHandler(Optional<Consumer<Throwable>> errorHandler);
+	SimpleReactStream<T> withSubscription(Continueable sub);
 	
 	abstract StreamWrapper getLastActive();
 	abstract ExecutorService getTaskExecutor();

--- a/src/main/java/com/aol/simple/react/stream/traits/FutureStream.java
+++ b/src/main/java/com/aol/simple/react/stream/traits/FutureStream.java
@@ -26,12 +26,11 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import org.jooq.lambda.Seq;
-import org.jooq.lambda.tuple.Tuple2;
 
 import com.aol.simple.react.async.Queue;
 import com.aol.simple.react.exceptions.SimpleReactFailedStageException;
+import com.aol.simple.react.stream.CloseableIterator;
 import com.aol.simple.react.stream.StreamWrapper;
-import com.aol.simple.react.stream.eager.EagerFutureStream;
 
 public interface FutureStream<U> extends Seq<U>,
 										ConfigurableStream<U>, 
@@ -153,7 +152,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default  void forEach(Consumer<? super U> action) {
-		toQueue().stream().forEach((Consumer) action);
+		toQueue().stream(getSubscription()).forEach((Consumer) action);
 
 	}
 
@@ -162,7 +161,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default  void forEachOrdered(Consumer<? super U> action) {
-		toQueue().stream().forEachOrdered((Consumer) action);
+		toQueue().stream(getSubscription()).forEachOrdered((Consumer) action);
 
 	}
 
@@ -171,7 +170,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default  Object[] toArray() {
-		return toQueue().stream().toArray();
+		return toQueue().stream(getSubscription()).toArray();
 	}
 
 	/* (non-Javadoc)
@@ -179,7 +178,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default  <A> A[] toArray(IntFunction<A[]> generator) {
-		return toQueue().stream().toArray(generator);
+		return toQueue().stream(getSubscription()).toArray(generator);
 	}
 
 	/* (non-Javadoc)
@@ -188,7 +187,7 @@ public interface FutureStream<U> extends Seq<U>,
 	@Override
 	default  U reduce(U identity, BinaryOperator<U> accumulator) {
 
-		return (U) toQueue().stream().reduce(identity, accumulator);
+		return (U) toQueue().stream(getSubscription()).reduce(identity, accumulator);
 	}
 
 	/*
@@ -198,7 +197,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default Optional<U> reduce(BinaryOperator<U> accumulator) {
-		return toQueue().stream().reduce(accumulator);
+		return toQueue().stream(getSubscription()).reduce(accumulator);
 	}
 
 	/*
@@ -211,7 +210,7 @@ public interface FutureStream<U> extends Seq<U>,
 	default  <R> R collect(Supplier<R> supplier,
 			BiConsumer<R, ? super U> accumulator, BiConsumer<R, R> combiner) {
 
-		return (R) toQueue().stream().collect(supplier, accumulator, combiner);
+		return (R) toQueue().stream(getSubscription()).collect(supplier, accumulator, combiner);
 	}
 
 
@@ -223,7 +222,7 @@ public interface FutureStream<U> extends Seq<U>,
 	@Override
 	default Optional<U> min(Comparator<? super U> comparator) {
 
-		return toQueue().stream().min(comparator);
+		return toQueue().stream(getSubscription()).min(comparator);
 	}
 
 	/*
@@ -233,7 +232,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default Optional<U> max(Comparator<? super U> comparator) {
-		return toQueue().stream().max(comparator);
+		return toQueue().stream(getSubscription()).max(comparator);
 	}
 
 	/*
@@ -254,7 +253,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default  boolean anyMatch(Predicate<? super U> predicate) {
-		return toQueue().stream().anyMatch(predicate);
+		return toQueue().stream(getSubscription()).anyMatch(predicate);
 	}
 
 	/*
@@ -264,7 +263,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default  boolean allMatch(Predicate<? super U> predicate) {
-		return toQueue().stream().allMatch(predicate);
+		return toQueue().stream(getSubscription()).allMatch(predicate);
 	}
 
 	/*
@@ -274,7 +273,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default boolean noneMatch(Predicate<? super U> predicate) {
-		return toQueue().stream().noneMatch(predicate);
+		return toQueue().stream(getSubscription()).noneMatch(predicate);
 	}
 
 	/*
@@ -284,7 +283,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default Optional<U> findFirst() {
-		return toQueue().stream().findFirst();
+		return toQueue().stream(getSubscription()).findFirst();
 	}
 
 	/*
@@ -294,7 +293,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default Optional<U> findAny() {
-		return toQueue().stream().findAny();
+		return toQueue().stream(getSubscription()).findAny();
 	}
 
 	/*
@@ -307,7 +306,7 @@ public interface FutureStream<U> extends Seq<U>,
 	default  <R> R reduce(R identity, BiFunction<R, ? super U, R> accumulator,
 			BinaryOperator<R> combiner) {
 
-		return toQueue().stream().reduce(identity, accumulator, combiner);
+		return toQueue().stream(getSubscription()).reduce(identity, accumulator, combiner);
 	}
 	/* (non-Javadoc)
 	 * @see java.util.stream.BaseStream#iterator()
@@ -315,7 +314,7 @@ public interface FutureStream<U> extends Seq<U>,
 	@Override
 	default Iterator<U> iterator() {
 
-		return toQueue().stream().iterator();
+		return new CloseableIterator<>(toQueue().stream(getSubscription()).iterator(),getSubscription());
 	}
 
 	/* (non-Javadoc)
@@ -323,7 +322,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default Spliterator<U> spliterator() {
-		return toQueue().stream().spliterator();
+		return toQueue().stream(getSubscription()).spliterator();
 	}
 
 	/* (non-Javadoc)
@@ -361,7 +360,7 @@ public interface FutureStream<U> extends Seq<U>,
 	
 	@Override
 	default  Stream<U> stream() {
-		return toQueue().stream();
+		return toQueue().stream(getSubscription());
 	}
 	
 	
@@ -489,7 +488,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default IntStream mapToInt(ToIntFunction<? super U> mapper) {
-		return toQueue().stream().mapToInt(mapper);
+		return toQueue().stream(getSubscription()).mapToInt(mapper);
 	}
 
 	/* (non-Javadoc)
@@ -497,7 +496,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default LongStream mapToLong(ToLongFunction<? super U> mapper) {
-		return toQueue().stream().mapToLong(mapper);
+		return toQueue().stream(getSubscription()).mapToLong(mapper);
 	}
 
 	/* (non-Javadoc)
@@ -505,7 +504,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default DoubleStream mapToDouble(ToDoubleFunction<? super U> mapper) {
-		return toQueue().stream().mapToDouble(mapper);
+		return toQueue().stream(getSubscription()).mapToDouble(mapper);
 	}
 
 	/* (non-Javadoc)
@@ -514,7 +513,7 @@ public interface FutureStream<U> extends Seq<U>,
 	@Override
 	default IntStream flatMapToInt(
 			Function<? super U, ? extends IntStream> mapper) {
-		return toQueue().stream().flatMapToInt(mapper);
+		return toQueue().stream(getSubscription()).flatMapToInt(mapper);
 	}
 
 	/* (non-Javadoc)
@@ -523,7 +522,7 @@ public interface FutureStream<U> extends Seq<U>,
 	@Override
 	default LongStream flatMapToLong(
 			Function<? super U, ? extends LongStream> mapper) {
-		return toQueue().stream().flatMapToLong(mapper);
+		return toQueue().stream(getSubscription()).flatMapToLong(mapper);
 	}
 
 	/* (non-Javadoc)
@@ -532,7 +531,7 @@ public interface FutureStream<U> extends Seq<U>,
 	@Override
 	default DoubleStream flatMapToDouble(
 			Function<? super U, ? extends DoubleStream> mapper) {
-		return toQueue().stream().flatMapToDouble(mapper);
+		return toQueue().stream(getSubscription()).flatMapToDouble(mapper);
 	}
 
 	
@@ -542,7 +541,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default Seq<U> sorted() {
-		return toQueue().stream().sorted();
+		return toQueue().stream(getSubscription()).sorted();
 	}
 
 	/* (non-Javadoc)
@@ -550,7 +549,7 @@ public interface FutureStream<U> extends Seq<U>,
 	 */
 	@Override
 	default Seq<U> sorted(Comparator<? super U> comparator) {
-		return toQueue().stream().sorted(comparator);
+		return toQueue().stream(getSubscription()).sorted(comparator);
 	}
 
 	/**

--- a/src/main/java/com/aol/simple/react/stream/traits/FutureStream.java
+++ b/src/main/java/com/aol/simple/react/stream/traits/FutureStream.java
@@ -1,5 +1,6 @@
 package com.aol.simple.react.stream.traits;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -314,6 +315,8 @@ public interface FutureStream<U> extends Seq<U>,
 	@Override
 	default Iterator<U> iterator() {
 
+		if(getSubscription().closed())
+			return Arrays.<U>asList().iterator();
 		return new CloseableIterator<>(toQueue().stream(getSubscription()).iterator(),getSubscription());
 	}
 

--- a/src/main/java/com/aol/simple/react/stream/traits/LazyStream.java
+++ b/src/main/java/com/aol/simple/react/stream/traits/LazyStream.java
@@ -41,6 +41,11 @@ public interface LazyStream<U> {
 		new SimpleReact(e).react(() -> new Runner(r).run(getLastActive(),new EmptyCollector(getLazyCollector().getMaxActive())));
 
 	}
+	default void run(Thread t,Runnable r) {
+		new Thread(() -> new Runner(r).run(getLastActive(),new EmptyCollector(getLazyCollector().getMaxActive()))).start();
+		//new SimpleReact(e).react(() -> new Runner(r).run(getLastActive(),new EmptyCollector(getLazyCollector().getMaxActive())));
+
+	}
 	/**
 	 * Trigger a lazy stream
 	 */

--- a/src/main/java/com/aol/simple/react/stream/traits/LazyToQueue.java
+++ b/src/main/java/com/aol/simple/react/stream/traits/LazyToQueue.java
@@ -1,5 +1,6 @@
 package com.aol.simple.react.stream.traits;
 
+import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.stream.Collector;
 
@@ -15,8 +16,8 @@ public interface LazyToQueue <U> extends ToQueue<U>{
 			final Function<T, R> fn);
 		
 	
-	abstract <R> SimpleReactStream<R> populate(final Function<U, R> fn);
-	
+	abstract <R> SimpleReactStream<R> then(final Function<U, R> fn, ExecutorService exec);
+	abstract ExecutorService getPopulator();
 
 	/**
 	 * Convert the current Stream to a SimpleReact Queue
@@ -27,12 +28,13 @@ public interface LazyToQueue <U> extends ToQueue<U>{
 		Queue<U> queue = this.getQueueFactory().build();
 		
 		
-			populate(queue::offer).run((Thread)null,
+			then(queue::offer,getPopulator()).run((Thread)null,
 					() -> queue.close());
 
 		
 		return queue;
 	}
+	
 	
 	default U add(U value,Queue<U> queue){
 		if(!queue.add(value))

--- a/src/main/java/com/aol/simple/react/stream/traits/LazyToQueue.java
+++ b/src/main/java/com/aol/simple/react/stream/traits/LazyToQueue.java
@@ -1,13 +1,9 @@
 package com.aol.simple.react.stream.traits;
 
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 import java.util.stream.Collector;
 
 import com.aol.simple.react.async.Queue;
-import com.aol.simple.react.async.QueueFactories;
 import com.aol.simple.react.async.QueueFactory;
 
 public interface LazyToQueue <U> extends ToQueue<U>{
@@ -18,7 +14,8 @@ public interface LazyToQueue <U> extends ToQueue<U>{
 	abstract <T, R>  SimpleReactStream<R> allOf(final Collector collector,
 			final Function<T, R> fn);
 		
-	abstract <R> SimpleReactStream<R> then(final Function<U, R> fn);	
+	
+	abstract <R> SimpleReactStream<R> populate(final Function<U, R> fn);
 	
 
 	/**
@@ -28,12 +25,18 @@ public interface LazyToQueue <U> extends ToQueue<U>{
 	 */
 	default Queue<U> toQueue() {
 		Queue<U> queue = this.getQueueFactory().build();
-
-
-			then(it -> queue.offer(it)).run(new ForkJoinPool(1),
+		
+		
+			populate(queue::offer).run((Thread)null,
 					() -> queue.close());
 
 		
 		return queue;
+	}
+	
+	default U add(U value,Queue<U> queue){
+		if(!queue.add(value))
+			throw new RuntimeException();
+		return value;
 	}
 }

--- a/src/main/java/com/aol/simple/react/stream/traits/SimpleReactStream.java
+++ b/src/main/java/com/aol/simple/react/stream/traits/SimpleReactStream.java
@@ -44,6 +44,18 @@ public interface SimpleReactStream<U> extends LazyStream<U>,
 
 	
 	Continueable getSubscription();
+	
+	default <R> SimpleReactStream<R> populate(final Function<U, R> fn) {
+		
+
+		
+		return (SimpleReactStream<R>) this.withLastActive(getLastActive().permutate(
+				getLastActive().stream().map(
+						(ft) -> ft.thenApplyAsync(SimpleReactStream.<U,R>handleExceptions(fn),
+								getTaskExecutor2())), Collectors.toList()));
+	}
+	
+	ExecutorService getTaskExecutor2();
 	/**
 	 * @param collector
 	 *            to perform aggregation / reduction operation on the results
@@ -123,6 +135,7 @@ public interface SimpleReactStream<U> extends LazyStream<U>,
 								getTaskExecutor())), Collectors.toList()));
 	}
 	
+	
 	default <R> SimpleReactStream<R> fromStream(Stream<R> stream) {
 		return (SimpleReactStream<R>) this.withLastActive(getLastActive()
 				.withNewStream(stream.map(CompletableFuture::completedFuture)));
@@ -187,6 +200,12 @@ public interface SimpleReactStream<U> extends LazyStream<U>,
 	 */
 	@SuppressWarnings("unchecked")
 	default  <R> SimpleReactStream<R> then(final Function<U, R> fn) {
+		return (SimpleReactStream<R>) this.withLastActive(getLastActive().permutate(
+				getLastActive().stream().map(
+						(ft) -> ft.thenApplyAsync(SimpleReactStream.<U,R>handleExceptions(fn),
+								getTaskExecutor())), Collectors.toList()));
+	}
+	default  <R> SimpleReactStream<R> until(final Function<U, R> fn) {
 		return (SimpleReactStream<R>) this.withLastActive(getLastActive().permutate(
 				getLastActive().stream().map(
 						(ft) -> ft.thenApplyAsync(SimpleReactStream.<U,R>handleExceptions(fn),

--- a/src/test/java/com/aol/simple/react/async/QueueTest.java
+++ b/src/test/java/com/aol/simple/react/async/QueueTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import com.aol.simple.react.stream.lazy.LazyFutureStream;
 import com.aol.simple.react.stream.simple.SimpleReact;
 import com.aol.simple.react.stream.traits.SimpleReactStream;
 
@@ -228,9 +229,9 @@ public class QueueTest {
 		count1 = 100000;
 
 		Queue<Integer> q = new Queue(new LinkedBlockingQueue());
-		parallelBuilder().reactInfinitely(() -> count++)
+		LazyFutureStream.parallelBuilder().reactInfinitely(() -> count++)
 				.then(it -> q.offer(it)).run(new ForkJoinPool(1));
-		parallelBuilder().reactInfinitely(() -> count1++)
+		LazyFutureStream.parallelBuilder().reactInfinitely(() -> count1++)
 				.then(it -> q.offer(it)).run(new ForkJoinPool(1));
 
 		List<Integer> result = q.stream().limit(1000)

--- a/src/test/java/com/aol/simple/react/base/BaseSeqTest.java
+++ b/src/test/java/com/aol/simple/react/base/BaseSeqTest.java
@@ -80,12 +80,14 @@ public abstract class BaseSeqTest {
 	}
 	@Test
 	public void zipInOrder(){
+		
 		List<Tuple2<Integer,Integer>> list =  of(1,2,3,4,5,6)
 													.zip( of(100,200,300,400))
 													.collect(Collectors.toList());
 		
 		assertThat(asList(1,2,3,4,5,6),hasItem(list.get(0).v1));
 		assertThat(asList(100,200,300,400),hasItem(list.get(0).v2));
+		
 		
 		
 	}

--- a/src/test/java/com/aol/simple/react/base/BaseSequentialSeqTest.java
+++ b/src/test/java/com/aol/simple/react/base/BaseSequentialSeqTest.java
@@ -26,7 +26,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.aol.simple.react.stream.eager.EagerFutureStream;
 import com.aol.simple.react.stream.traits.FutureStream;
 
 public abstract class BaseSequentialSeqTest {
@@ -95,18 +94,21 @@ public abstract class BaseSequentialSeqTest {
 	}
 	@Test
 	public void zipInOrder(){
-		List<Tuple2<Integer,Integer>> list =  of(1,2,3,4,5,6).limit(6)
-													.zip( of(100,200,300,400).limit(4))
-													.collect(Collectors.toList());
 		
-		assertThat(list.get(0).v1,is(1));
-		assertThat(list.get(0).v2,is(100));
-		assertThat(list.get(1).v1,is(2));
-		assertThat(list.get(1).v2,is(200));
-		assertThat(list.get(2).v1,is(3));
-		assertThat(list.get(2).v2,is(300));
-		assertThat(list.get(3).v1,is(4));
-		assertThat(list.get(3).v2,is(400));
+		//this is not 100% reliable for EagerFutureStream use zipFutures instead
+			List<Tuple2<Integer,Integer>> list =  of(1,2,3,4,5,6).limit(6)
+														.zip( of(100,200,300,400).limit(4))
+														.collect(Collectors.toList());
+			
+			assertThat(list.get(0).v1,is(1));
+			assertThat(list.get(0).v2,is(100));
+			assertThat(list.get(1).v1,is(2));
+			assertThat(list.get(1).v2,is(200));
+			assertThat(list.get(2).v1,is(3));
+			assertThat(list.get(2).v2,is(300));
+			assertThat(list.get(3).v1,is(4));
+			assertThat(list.get(3).v2,is(400));
+		
 		
 		
 	}

--- a/src/test/java/com/aol/simple/react/eager/AnyOfTest.java
+++ b/src/test/java/com/aol/simple/react/eager/AnyOfTest.java
@@ -96,7 +96,6 @@ public class AnyOfTest {
 	public void testAnyOfCompletableFilterNoError(){
 	
 		String result = new EagerReact().of("hello","world","2")
-				.onFail(it ->"hello")
 				.filter(it-> !"2".equals(it))
 				.peek(it -> 
 				System.out.println(it))

--- a/src/test/java/com/aol/simple/react/eager/EagerSeqTest.java
+++ b/src/test/java/com/aol/simple/react/eager/EagerSeqTest.java
@@ -26,6 +26,7 @@ public class EagerSeqTest extends BaseSeqTest {
 	protected <U> EagerFutureStream<U> of(U... array) {
 		return EagerFutureStream.parallel(array);
 	}
+	
 
 	@Test
 	public void testOfType() {

--- a/src/test/java/com/aol/simple/react/lazy/AutoclosingTest.java
+++ b/src/test/java/com/aol/simple/react/lazy/AutoclosingTest.java
@@ -1,0 +1,106 @@
+package com.aol.simple.react.lazy;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.jooq.lambda.tuple.Tuple2;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.aol.simple.react.async.Queue;
+import com.aol.simple.react.stream.lazy.LazyFutureStream;
+import com.aol.simple.react.stream.lazy.LazyReact;
+
+public class AutoclosingTest {
+
+	
+	@Test
+	public void autoClosingLimit1() throws InterruptedException{
+		close = new AtomicInteger();
+		added = new AtomicInteger();
+		//subscription fills from outside in (right to left), need to store open / closed for each queue
+		List<String> results = new LazyReact().reactInfinitely(()->nextValues()).withQueueFactory(()-> eventQueue())
+													  .flatMap(list -> list.stream())
+													  .peek(System.out::println)
+													  .flatMap(list -> list.stream())
+													  .peek(System.out::println)
+													  .limit(1)
+													  .collect(Collectors.toList());
+		System.out.println("finished");
+		int localAdded = added.get();
+		assertThat(close.get(),greaterThan(0));
+		assertThat(results.size(),is(1));
+		assertThat(localAdded,is(added.get()));
+		
+	}
+
+	@Test 
+	public void autoClosingLimit2Limit1() throws InterruptedException{
+		System.out.println("Last test!!");
+		close = new AtomicInteger();
+		added = new AtomicInteger();
+		//subscription fills from outside in (right to left), need to store open / closed for each queue
+		List<String> results = new LazyReact().reactInfinitely(()->nextValues()).withQueueFactory(()-> eventQueue())
+													  .flatMap(list -> list.stream())
+													  .peek(System.out::println)
+													  .limit(2)
+													  .flatMap(list -> list.stream())
+													  .peek(System.out::println)
+													  .limit(1)
+													  .collect(Collectors.toList());
+		System.out.println("finished");
+	
+		
+		
+		int localAdded = added.get();
+		assertThat(close.get(),greaterThan(0));
+		assertThat(results.size(),is(1));
+		assertThat(localAdded,is(added.get()));
+		
+	}
+	@Test
+	public void autoClosingZip() throws InterruptedException{
+		close = new AtomicInteger();
+		added = new AtomicInteger();
+		//subscription fills from outside in (right to left), need to store open / closed for each queue
+		List<Tuple2<List<List<String>>, Integer>> results = new LazyReact().reactInfinitely(()->nextValues()).withQueueFactory(()-> eventQueue())
+													  .zip(LazyFutureStream.parallel(1,2,3))
+													  .collect(Collectors.toList());
+		System.out.println("finished");
+	
+		
+		
+		int localAdded = added.get();
+		assertThat(close.get(),greaterThan(0));
+		assertThat(results.size(),is(3));
+		assertThat(localAdded,is(added.get()));
+		
+	}
+	AtomicInteger added;
+	AtomicInteger close;
+	private Queue<List<List<String>>> eventQueue() {
+		System.out.println("new event queue!");
+		return new Queue(new LinkedBlockingQueue<>(100)){
+
+			@Override
+			public void closeAndClear() {
+				close.incrementAndGet();
+				super.closeAndClear();
+			}
+			
+		};
+		
+	}
+
+	private List<List<String>> nextValues() {
+		added.incrementAndGet();
+		return  asList(asList("1","2"),asList("1","2"));
+	}
+}

--- a/src/test/java/com/aol/simple/react/lazy/AutoclosingTest.java
+++ b/src/test/java/com/aol/simple/react/lazy/AutoclosingTest.java
@@ -5,13 +5,13 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.jooq.lambda.tuple.Tuple2;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.aol.simple.react.async.Queue;
@@ -87,9 +87,51 @@ public class AutoclosingTest {
 		assertThat(localAdded,is(added.get()));
 		
 	}
+	
+	@Test 
+	public void autoClosingIterate() throws InterruptedException{
+		System.out.println("Last test!!");
+		close = new AtomicInteger();
+		added = new AtomicInteger();
+		
+	
+		//subscription fills from outside in (right to left), need to store open / closed for each queue
+		List<Integer> results = new LazyReact().iterateInfinitely(0,val->val+1).withQueueFactory(()-> eventQueueInts())
+													  .flatMap(val -> asList(asList(val,1,2,3)).stream())
+													  .peek(System.out::println)
+													  .limit(2)
+													  .flatMap(list -> list.stream())
+													  .peek(System.out::println)
+													  .limit(1)
+													  .collect(Collectors.toList());
+		
+		System.out.println("finished");
+	
+		Thread.sleep(1000);
+		
+		int localAdded = added.get();
+		assertThat(close.get(),greaterThan(0));
+		assertThat(results.size(),is(1));
+		assertThat(localAdded,is(added.get()));
+		
+	}
+	
 	AtomicInteger added;
 	AtomicInteger close;
 	private Queue<List<List<String>>> eventQueue() {
+		System.out.println("new event queue!");
+		return new Queue(new LinkedBlockingQueue<>(100)){
+
+			@Override
+			public void closeAndClear() {
+				close.incrementAndGet();
+				super.closeAndClear();
+			}
+			
+		};
+		
+	}
+	private Queue<Integer> eventQueueInts() {
 		System.out.println("new event queue!");
 		return new Queue(new LinkedBlockingQueue<>(100)){
 

--- a/src/test/java/com/aol/simple/react/lazy/AutoclosingTest.java
+++ b/src/test/java/com/aol/simple/react/lazy/AutoclosingTest.java
@@ -46,6 +46,8 @@ public class AutoclosingTest {
 		System.out.println("Last test!!");
 		close = new AtomicInteger();
 		added = new AtomicInteger();
+		
+	
 		//subscription fills from outside in (right to left), need to store open / closed for each queue
 		List<String> results = new LazyReact().reactInfinitely(()->nextValues()).withQueueFactory(()-> eventQueue())
 													  .flatMap(list -> list.stream())
@@ -55,9 +57,10 @@ public class AutoclosingTest {
 													  .peek(System.out::println)
 													  .limit(1)
 													  .collect(Collectors.toList());
+		
 		System.out.println("finished");
 	
-		
+		Thread.sleep(1000);
 		
 		int localAdded = added.get();
 		assertThat(close.get(),greaterThan(0));
@@ -67,6 +70,7 @@ public class AutoclosingTest {
 	}
 	@Test
 	public void autoClosingZip() throws InterruptedException{
+		System.out.println("Started!");
 		close = new AtomicInteger();
 		added = new AtomicInteger();
 		//subscription fills from outside in (right to left), need to store open / closed for each queue
@@ -100,6 +104,7 @@ public class AutoclosingTest {
 	}
 
 	private List<List<String>> nextValues() {
+		System.out.println("added!");
 		added.incrementAndGet();
 		return  asList(asList("1","2"),asList("1","2"));
 	}

--- a/src/test/java/com/aol/simple/react/lazy/LazySeqTest.java
+++ b/src/test/java/com/aol/simple/react/lazy/LazySeqTest.java
@@ -39,8 +39,10 @@ public class LazySeqTest extends BaseSeqTest {
 	@Test
 	public void testBackPressureWhenZippingUnevenStreams() throws InterruptedException {
 
-		Queue fast = parallelBuilder().withExecutor(new ForkJoinPool(2)).reactInfinitely(() -> "100")
-				.withQueueFactory(QueueFactories.boundedQueue(2)).toQueue();
+		LazyFutureStream stream =  parallelBuilder().withExecutor(new ForkJoinPool(2))
+								.reactInfinitely(() -> "100").peek(System.out::println)
+				.withQueueFactory(QueueFactories.boundedQueue(2));
+		Queue fast = stream.toQueue();
 
 		Thread t = new Thread(() -> {
 			parallelBuilder().withExecutor(new ForkJoinPool(2)).react(() -> 1, SimpleReact.times(10)).peek(c -> sleep(10))

--- a/src/test/java/com/aol/simple/react/simple/AnyOfTest.java
+++ b/src/test/java/com/aol/simple/react/simple/AnyOfTest.java
@@ -117,10 +117,8 @@ public class AnyOfTest {
 				.<CompletableFuture<String>>map(it ->  handle(it)))
 				.onFail(it ->"hello")
 				.filter(it-> !"2".equals(it))
-				.capture(e -> 
-				  e.printStackTrace())
-				.peek(it -> 
-				System.out.println(it))
+				.capture(Throwable::printStackTrace)
+				.peek(System.out::println)
 				.anyOf(data -> {
 					System.out.println(data);
 						return data; }).first();

--- a/src/test/java/com/aol/simple/react/simple/OnFailTest.java
+++ b/src/test/java/com/aol/simple/react/simple/OnFailTest.java
@@ -3,10 +3,8 @@ package com.aol.simple.react.simple;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,9 +25,6 @@ public class OnFailTest {
 	}
 	@Test
 	public void chained(){
-		
-		
-		
 		new SimpleReact().react(()->1,()->2)
 			.then(this::throwException)
 			.onFail(IOException.class, e-> shouldNeverBeCalled.incrementAndGet())
@@ -37,43 +32,10 @@ public class OnFailTest {
 			.onFail(ClosedQueueException.class, e-> shouldNeverBeReached.incrementAndGet())
 			.block();
 		
-		
-		
-		
-		
 		assertThat(shouldNeverBeCalled.get(),equalTo(0));
 		assertThat(shouldBeCalled.get(),equalTo(2));
 		assertThat(shouldNeverBeReached.get(),equalTo(0));
 		
-	}
-	
-	@Test
-	public void test(){
-		
-		
-		
-		new SimpleReact().react(()->1,()->2)
-			.then(this::throwException)
-			.onFail(IOException.class, e-> handleIO(e.getValue()))
-			.onFail(RuntimeException.class, e-> handleRuntime(e.getValue()))
-			.block();
-		
-		
-		
-		
-		
-		assertThat(shouldNeverBeCalled.get(),equalTo(0));
-		assertThat(shouldBeCalled.get(),equalTo(2));
-		assertThat(shouldNeverBeReached.get(),equalTo(0));
-		
-	}
-	private  Integer handleRuntime(Integer value) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-	private Integer handleIO(Integer value) {
-		// TODO Auto-generated method stub
-		return null;
 	}
 	private int throwException(int num) {
 		throw new MyRuntimeTimeException();


### PR DESCRIPTION
simple-react uses async.Queues to implement some functionality internally. For LazyFutureStreams this can potentially result in data infinetely populating a queue (or blocking trying to) unless users managed this manually. 
This feature will automatically close intermediate / internal queues used in simple-react without requiring manual intervention from the user.