### PR TITLE
fixes aol/simple-react#28

### DIFF
--- a/src/main/java/com/aol/simple/react/stream/Status.java
+++ b/src/main/java/com/aol/simple/react/stream/Status.java
@@ -27,7 +27,7 @@ public class Status<T> {
 	}
 	
 	public final long getElapsedMillis(){
-		return elapsedNanos * 1000000;
+		return elapsedNanos / 1000000;
 	}
 
 	public int getCompleted() {

--- a/src/test/java/com/aol/simple/react/stream/StatusTest.java
+++ b/src/test/java/com/aol/simple/react/stream/StatusTest.java
@@ -1,0 +1,15 @@
+package com.aol.simple.react.stream;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class StatusTest {
+
+    @Test
+    public void testGetMillis() {
+        Status status = new Status(0, 0, 0, 1000000L, null);
+        assertThat(status.getElapsedMillis(), is(1L));
+    }
+}


### PR DESCRIPTION
Changed the getMillis method to divide by 1m (instead of multiply) when converting nanoseconds to milliseconds.