### PR TITLE
partitionEithers, lefts, rights

### DIFF
--- a/cyclops/src/main/java/cyclops/companion/Streams.java
+++ b/cyclops/src/main/java/cyclops/companion/Streams.java
@@ -1901,12 +1901,12 @@ public class Streams {
     }
 
     public final static <T> String join(final Stream<T> stream, final String sep) {
-        return stream.map(t -> t.toString())
+        return stream.map(t -> t!=null ? t.toString() : "null")
                      .collect(java.util.stream.Collectors.joining(sep));
     }
 
     public final static <T> String join(final Stream<T> stream, final String sep, final String start, final String end) {
-        return stream.map(t -> t.toString())
+        return stream.map(t -> t!=null ? t.toString() : "null")
                      .collect(java.util.stream.Collectors.joining(sep, start, end));
     }
 

--- a/cyclops/src/test/java/cyclops/control/either/EitherTest.java
+++ b/cyclops/src/test/java/cyclops/control/either/EitherTest.java
@@ -28,6 +28,7 @@ public class EitherTest {
 
     @Test
     public void partitionEithersOrdered(){
+
         Seq<Either<Integer,String>> s = Seq.of(right("hello"),left(1),right("world"),left(2));
         Tuple2<Vector<Integer>, Vector<String>> v = Either.partitionEithers(s);
         Vector<Integer> ints = v._1();

--- a/cyclops/src/test/java/cyclops/control/either/EitherTest.java
+++ b/cyclops/src/test/java/cyclops/control/either/EitherTest.java
@@ -5,11 +5,16 @@ import cyclops.data.LazySeq;
 import cyclops.companion.Monoids;
 import cyclops.companion.Semigroups;
 
+import cyclops.data.Seq;
 import cyclops.data.Vector;
+import cyclops.data.tuple.Tuple;
+import cyclops.data.tuple.Tuple2;
 import org.junit.Test;
 
 import java.util.Arrays;
 
+import static cyclops.control.Either.left;
+import static cyclops.control.Either.right;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 public class EitherTest {
@@ -20,14 +25,71 @@ public class EitherTest {
 	public static class Base{ }
     public static class One extends Base{ }
     public static class Two extends Base{}
+
+    @Test
+    public void partitionEithersOrdered(){
+        Seq<Either<Integer,String>> s = Seq.of(right("hello"),left(1),right("world"),left(2));
+        Tuple2<Vector<Integer>, Vector<String>> v = Either.partitionEithers(s);
+        Vector<Integer> ints = v._1();
+        Vector<String> strs = v._2();
+        System.out.println("ints " + ints);
+        System.out.println("strs " + strs);
+        System.out.println(v);
+        assertThat(Either.partitionEithers(s),equalTo(Tuple.tuple(Seq.of(1,2),Seq.of("hello","world"))));
+    }
+    @Test
+    public void partitionEithersVector(){
+        Vector<Either<Integer,String>> s = Vector.of(right("hello"),left(1),right("world"),left(2));
+        assertThat(Either.partitionEithers(s),equalTo(Tuple.tuple(Seq.of(1,2),Seq.of("hello","world"))));
+    }
+    @Test
+    public void partitionEithersEmpty(){
+        Vector<Either<Integer,String>> s = Vector.of();
+        assertThat(Either.partitionEithers(s),equalTo(Tuple.tuple(Seq.of(),Seq.of())));
+    }
+
+    @Test
+    public void leftEithersOrdered(){
+        Seq<Either<Integer,String>> s = Seq.of(right("hello"),left(1),right("world"),left(2));
+
+        assertThat(Either.lefts(s),equalTo(Seq.of(1,2)));
+    }
+    @Test
+    public void leftsEithersVector(){
+        Vector<Either<Integer,String>> s = Vector.of(right("hello"),left(1),right("world"),left(2));
+        assertThat(Either.lefts(s),equalTo(Seq.of(1,2)));
+    }
+    @Test
+    public void leftsEithersEmpty(){
+        Vector<Either<Integer,String>> s = Vector.of();
+        assertThat(Either.lefts(s),equalTo(Seq.of()));
+    }
+
+    @Test
+    public void rightsEithersOrdered(){
+        Seq<Either<Integer,String>> s = Seq.of(right("hello"),left(1),right("world"),left(2));
+
+        assertThat(Either.rights(s),equalTo(Seq.of("hello","world")));
+    }
+    @Test
+    public void rightsEithersVector(){
+        Vector<Either<Integer,String>> s = Vector.of(right("hello"),left(1),right("world"),left(2));
+        assertThat(Either.rights(s),equalTo(Seq.of("hello","world")));
+    }
+    @Test
+    public void rightsEithersEmpty(){
+        Vector<Either<Integer,String>> s = Vector.of();
+        assertThat(Either.rights(s),equalTo(Seq.of()));
+    }
+
     @Test
     public void visitAny(){
 
-        Either<One,Two> test = Either.right(new Two());
+        Either<One,Two> test = right(new Two());
         test.to(Either::applyAny).apply(b->b.toString());
-        Either.right(10).to(Either::consumeAny).accept(System.out::println);
-        Either.right(10).to(e-> Either.visitAny(System.out::println,e));
-        Object value = Either.right(10).to(e-> Either.visitAny(e, x->x));
+        right(10).to(Either::consumeAny).accept(System.out::println);
+        right(10).to(e-> Either.visitAny(System.out::println,e));
+        Object value = right(10).to(e-> Either.visitAny(e, x->x));
         assertThat(value,equalTo(10));
     }
 
@@ -38,9 +100,9 @@ public class EitherTest {
 
 
 
-		assertThat(Either.accumulateLeft(Monoids.stringConcat, Arrays.asList(Either.left("failed1"),
-													Either.left("failed2"),
-													Either.right("success"))
+		assertThat(Either.accumulateLeft(Monoids.stringConcat, Arrays.asList(left("failed1"),
+													left("failed2"),
+													right("success"))
 													).orElse(":"),equalTo("failed1failed2"));
 
 	}
@@ -52,25 +114,25 @@ public class EitherTest {
 
 	@Test
 	public void applicative(){
-	    Either<String,String> fail1 =  Either.left("failed1");
-	    Either<String,String> result = fail1.combine(Either.left("failed2"), Semigroups.stringConcat,(a, b)->a+b);
+	    Either<String,String> fail1 =  left("failed1");
+	    Either<String,String> result = fail1.combine(left("failed2"), Semigroups.stringConcat,(a, b)->a+b);
 	    assertThat(result.leftOrElse(":"),equalTo("failed2failed1"));
 	}
 	@Test
     public void applicativeColleciton(){
-        Either<String,String> fail1 =  Either.left("failed1");
-        Either<LazySeq<String>,String> result = fail1.lazySeq().combine(Either.left("failed2").lazySeq(), Semigroups.lazySeqConcat(),(a, b)->a+b);
+        Either<String,String> fail1 =  left("failed1");
+        Either<LazySeq<String>,String> result = fail1.lazySeq().combine(left("failed2").lazySeq(), Semigroups.lazySeqConcat(),(a, b)->a+b);
         assertThat(result.leftOrElse(LazySeq.empty()),equalTo(LazySeq.of("failed2","failed1")));
     }
 	@Test
     public void applicativeLazySeq(){
-        Either<String,String> fail1 =  Either.left("failed1");
+        Either<String,String> fail1 =  left("failed1");
         Either<LazySeq<String>,String> result = fail1.combineToLazySeq(Either.<String,String>left("failed2"),(a, b)->a+b);
         assertThat(result.leftOrElse(LazySeq.empty()),equalTo(LazySeq.of("failed2","failed1")));
     }
     @Test
     public void applicativeVector(){
-        Either<String,String> fail1 =  Either.left("failed1");
+        Either<String,String> fail1 =  left("failed1");
         Either<Vector<String>,String> result = fail1.combineToVector(Either.<String,String>left("failed2"),(a, b)->a+b);
         assertThat(result.leftOrElse(Vector.empty()),equalTo(Vector.of("failed2","failed1")));
     }

--- a/cyclops/src/test/java/cyclops/data/basetests/AbstractIterableXTest.java
+++ b/cyclops/src/test/java/cyclops/data/basetests/AbstractIterableXTest.java
@@ -79,6 +79,10 @@ public abstract class AbstractIterableXTest {
     boolean set = false;
 
     @Test
+    public void printNull(){
+        System.out.println(of(new String[]{null}));
+    }
+    @Test
     public void zip2Seq() {
         IterableX<Integer> it1 = of(1);
         IterableX<Integer> it2 = of(2);


### PR DESCRIPTION
Impl for #1088

Partition an Iterable of Eithers into two Vectors one with the lefts, one with the rights.

Also add methods to extract only the lefts and the rights.
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
